### PR TITLE
Changes needed for displaying the Brickly user guide on http://cfw.ftcommunity.de/

### DIFF
--- a/de/brickly/index.md
+++ b/de/brickly/index.md
@@ -1,4 +1,5 @@
 # Brickly
+
 Brickly ist eine graphische Entwicklungsumgebung für die [Community Edition Firmware](http://cfw.ftcommunity.de/ftcommunity-TXT/de/) des Fischertechnik TXT. Sie basiert auf Google Blockly.  
 
 # Wozu braucht man Brickly?  

--- a/de/brickly/index.md
+++ b/de/brickly/index.md
@@ -5,7 +5,7 @@ Brickly ist eine graphische Entwicklungsumgebung für die [Community Edition Fir
 # Wozu braucht man Brickly?  
 Mit Brickly kannst du im Browser, z.B. auf einem Tablet oder einem PC, graphisch Programme erstellen, die auf dem TXT laufen. Der TXT dient dabei als Webserver, auf den du über WLAN zugreifen kannst. Die Programme können die Eingänge des TXT auslesen und seine Ausgänge, z.B. für Motoren ansteuern.    
 
-![Brickly im Browser](/de/brickly/Screenshot_Brickly.png)
+![Brickly im Browser](Screenshot_Brickly.png)
 
 Du programmierst mit Brickly, indem du im Browser mit der Maus Bausteine zu einem Programm zusammenfügst. Um dir den Einstieg zu erleichtern, stehen fünf verschiedene Erfahrungsgrade zur Verfügung. Die Programme werden auf dem TXT gespeichert, können aber auch (mit der App [BrickMCP](https://github.com/ftCommunity/ftcommunity-apps/blob/master/packages/BrickMCP.zip)) auf andere Rechner übertragen werden.  
 
@@ -15,13 +15,13 @@ Brickly kannst du als [Zip-Datei](https://github.com/ftCommunity/ftcommunity-app
 ## Start im Web-Interface  
 Im Web-Interface kannst du Brickly jetzt auswählen.  
 
-![Brickly-Symbol](/de/brickly/bricklysymbol.png)
+![Brickly-Symbol](bricklysymbol.png)
 
 Auf der nächsten Seite kommst du mit "Open local application pages" auf die Seite von Brickly. Damit du mit Brickly programmieren kannst, muss im Browser die Ausführung von JavaScript möglich sein. Auf der Brickly-Seite kannst Du auch die Sprache auswählen, entweder Deutsch oder Englisch (mit den Flaggen-Symbolen rechts oben in der Ecke). Außerdem kannst du dein Brickly-Programm ausdrucken: wenn du auf das Drucker-Symbol rechts oben drückst, erhälst du ein Bild von deinem Programm, das du mit der Druck-Funktion deines Browsers drucken kannst.  
 
 ## Benutzung auf dem TXT-Touch-Screen  
-![TXT: Brickly](/de/brickly/TXT_Brickly.png)  
+![TXT: Brickly](TXT_Brickly.png)  
 Hier siehst du, wie Brickly auf dem TXT-Touch-Screen aussieht. Programmieren kannst du nur in dem Browser auf dem deinem PC oder Tablet. Auf dem TXT kannst du ein Programm auswählen (mit "Select..."). Wenn du auf "Run" drückst, startet das Programm. Wenn du Brickly auf dem TXT beenden willst, drückst du einfach auf das X rechts oben. Wenn du Brickly auf dem TXT beendet hast und das Browserfenster noch offen ist, kannst du durch Drücken auf "Verbinde" rechts im Browser Brickly wieder starten.    
 
 ## Arbeiten mit Brickly  
-In den folgenden Seiten kannst Du für jeden Erfahrungsgrad nachlesen, welche Bausteine dir dir zur Verfügung stehen. Grundlegende Erklärungen gibt es auf der Seite ["Anfänger"](/de/brickly/level-1.md).  
+In den folgenden Seiten kannst Du für jeden Erfahrungsgrad nachlesen, welche Bausteine dir dir zur Verfügung stehen. Grundlegende Erklärungen gibt es auf der Seite ["Anfänger"](level-1.md).  

--- a/de/brickly/level-1.md
+++ b/de/brickly/level-1.md
@@ -1,4 +1,5 @@
 # Erster Erfahrungsgrad "Anfänger"<a name="Erster"></a>  
+
 Oben links auf der Startseite von Brickly siehst du fünf kleine Kreise mit Zahlen. Hier wählst du die 1 aus. Du kommst damit zu dem Erfahrungsgrad "Anfänger".  
   
 ![Startseite von Brickly](/de/brickly/Seite.png)  

--- a/de/brickly/level-1.md
+++ b/de/brickly/level-1.md
@@ -2,12 +2,12 @@
 
 Oben links auf der Startseite von Brickly siehst du fünf kleine Kreise mit Zahlen. Hier wählst du die 1 aus. Du kommst damit zu dem Erfahrungsgrad "Anfänger".  
   
-![Startseite von Brickly](/de/brickly/Seite.png)  
+![Startseite von Brickly](Seite.png)  
 
 Auf der linken Seite siehst Du einige Bausteine, aus denen du dein Programm zusammenbauen kannst. In der Mitte ist deine Arbeitsfläche. Ganz rechts siehst du einen blauen Kasten. Hier wird der Text erscheinen, der von Brickly ausgegeben wird, aber auch Fehlermeldungen, wenn etwas ganz schief laufen sollte.   
 In der Arbeitsfläche siehst du schon einen ersten Baustein. Mit diesem Anfangsbaustein beginnt dein Programm. Ziehe mit der Maus einen Baustein von der linken Seite hierher. Du siehst, dass der Nippel auf der Unterseite des Anfangsbausteins gelb aufleuchtet. Jetzt kannst du deinen Baustein hier ablegen. 
 
-![Baubeginn](/de/brickly/buildstart.png)
+![Baubeginn](buildstart.png)
 
 Bei manchen Bausteinen kannst du etwas auswählen. Dazu drückst du auf das kleine blaue Dreieck in dem Auswahlfeld. Wenn du eine Reihe von Bausteinen untereinander zusammengefügt hast, kannst du auf "Los" (über dem blauen Kasten auf der rechten Seite) drücken. Damit wird dein Programm auf den TXT hochgeladen und dort gleich gestartet. Die Befehle auf den Bausteinen werden jetzt von oben nach unten nacheinander abgearbeitet. Wenn das Programm fertig ist, werden alle Ausgänge wieder zurückgesetzt, also z.B. alle Motoren gestoppt.  
 
@@ -15,12 +15,12 @@ Bei manchen Bausteinen kannst du etwas auswählen. Dazu drückst du auf das klei
 * `gib aus <Text>`<a name="gibaus"></a>Statt *Text* kannst du hier über die Tastatur an deinem Rechner einen anderen Text eingeben. Drücke dazu in das Feld und schreibe deinen Text, z.B. "Hallo TXT". Beende die Eingabe mit der Eingabetaste auf deiner Tastatur oder indem du (mit der Maus) irgendwohin drückst. Wenn das Programm läuft, erscheint der Text in dem blauen Kasten auf der rechten Seite und auf dem Touchscreen deines TXT.   
 * `schalte Ausgang <O1> <aus>`<a name="schalteAusgang"></a>: Mit diesem Baustein kannst du direkt einen Ausgang am TXT ansteuern, um z.B. eine Lampe leuchten zu lassen. Mit *ein* schaltest du den Ausgang ein, mit *aus* wieder aus. Achte darauf, den richtigen Ausgang auszuwählen, also den, an dem du auf dem TXT deine Lampe oder deinen Motor angeschlossen hast. Denk daran, das am Programmende alle Ausgänge wieder ausgeschaltet werden und verwende einen *warte*-Baustein, wenn es nötig ist.  
   
-![Auswahlbox](/de/brickly/selectionbox.png)  
+![Auswahlbox](selectionbox.png)  
   
 * `warte <1> Sekunden`<a name="warte"></a>: der TXT macht 1 Sekunde lang nicht mit dem Programm weiter. Du kannst hier auch eine andere Zahl eingeben. Wähle aber keine zu lange Zeit, sonst wird dir langweilig.    
 * `wiederhole`<a name="wiederhole"></a>: Wenn du einen Befehl oder eine Gruppe von Befehlen nicht nur einmal, sondern immer wieder ausführen möchtest, verwendest du den *wiederhole*-Baustein. Die Befehlsbausteine schiebst du in den Bauch in dem Wiederhole-Baustein. Jetzt hast du ein Programm, das immer wieder durchläuft. 
   
-![Wiederhole](/de/brickly/loop.png)
+![Wiederhole](loop.png)
   
 Zum Stoppen des Programms musst du auf den "Stopp"-Knopf drücken. Du findest den "Stopp"-Knopf rechts oben über dem blauen Kasten, da, wo vorher der "Los"-Knopf war.   
 * `fahre <vorwärts> <25> cm`<a name="fahre"></a>: Damit kannst du den Fahrroboter aus dem Fischertechnik TXT Discovery Set 25 cm geradeaus vorwärts fahren lassen. Statt *vorwärts* kannst du auch *rückwärts* auswählen, und du kannst eine längere Strecke eingeben. Mehr als 47 cm sind aber nicht möglich.    
@@ -28,7 +28,7 @@ Zum Stoppen des Programms musst du auf den "Stopp"-Knopf drücken. Du findest de
 
 ## Kontextmenü  
 
-![Kontextmenü]( /de/brickly/contextmenu.png)
+![Kontextmenü]( contextmenu.png)
 
 Wenn du auf die rechte Maustaste drückst, öffnet sich ein Kontextmenü. Hier hast du drei Punkte zur Auswahl:    
 * "Kopieren": damit kannst du den ausgewählten Baustein kopieren und die Kopie woanders einbauen.

--- a/de/brickly/level-2.md
+++ b/de/brickly/level-2.md
@@ -1,4 +1,5 @@
 # Zweiter Erfahrungsgrad "Junior"    
+
 Als "Junior" hast du mehr Bausteine zur Verfügung. Damit die Auswahl übersichtlich bleibt, sind die Bausteine jetzt in Gruppen aufgeteilt.
 
 ![Gruppen](/de/brickly/gruppen.png)

--- a/de/brickly/level-2.md
+++ b/de/brickly/level-2.md
@@ -2,25 +2,25 @@
 
 Als "Junior" hast du mehr Bausteine zur Verfügung. Damit die Auswahl übersichtlich bleibt, sind die Bausteine jetzt in Gruppen aufgeteilt.
 
-![Gruppen](/de/brickly/gruppen.png)
+![Gruppen](gruppen.png)
 
 Es gibt jetzt einen Mülleimer, in den du Bausteine, die du nicht mehr haben willst, schieben kannst. Außerdem kannst du rechts unten die Geschwindigkeit auswählen, mit der der TXT das Programm abarbeiten soll: von Schildkrötengang (ganz langsam) bis zu Hasengang (ganz schnell).  
 Neue Bausteine in "Junior" beschäftigen sich mit Bedingungen und Logik. Eine Bedingung ist entweder *wahr* oder *unwahr*. Es gibt für diese Bedingungen beim Programmieren kein "vielleicht" oder "ich weiß nicht". Eine Bedingung in Brickly ist z.B. `Eingang <I1> ist an`. Der Eingang ist an, dann ist die Bedingung wahr, oder aus, dann ist die Bedingung unwahr.   Bedingungsbausteine kannst du an verschiedenen Stellen einsetzen, z.B bei `wiederhole <solange>`.  
 
 ## Bausteine "Spezial"    
-* `warte <1> Sekunden`: s. [hier](/de/brickly/level-1.md#warte)  
+* `warte <1> Sekunden`: s. [hier](level-1.md#warte)  
 * `spiele Geräusch` und `Flugzeug`: der TXT macht das ausgewählte Geräusch, z.B. *Flugzeug*. Du kannst aus einer ganzen Reihe von Geräuschen auswählen. Den Geräusch-Baustein musst du rechts an den Befehlsbaustein anbauen.   
 
 ## Bausteine "Eingänge"        
 * `Eingang <I1> ist an`: Dies ist ein Bedingungs-Baustein, der den Zustand des ausgewählten Eingangs, z.B. *I1* abfragt.      
 
 ## Bausteine "Ausgänge"    
-* `schalte Ausgang <O1>` und `ein`: s. [hier](/de/brickly/level-1.md#schalteAusgang)  
-* `fahre <vorwärts> <25> cm`: s. [hier](/de/brickly/level-1.md#fahre)  
-* `drehe <rechts> <halb> herum`: s. [hier](/de/brickly/level-1.md#drehe)  
+* `schalte Ausgang <O1>` und `ein`: s. [hier](level-1.md#schalteAusgang)  
+* `fahre <vorwärts> <25> cm`: s. [hier](level-1.md#fahre)  
+* `drehe <rechts> <halb> herum`: s. [hier](level-1.md#drehe)  
 * `fahre <vorwärts> <solange>`<a name="fahresolange"></a>: Mit diesem Baustein kannst du den Fahrroboter solange *vorwärts* oder *rückwärts* fahren lassen, wie ein Zustand dauert, also die angegebene Bedingung wahr ist. Als Zustand kannst du den `Eingang <I1> ist an`-Baustein nehmen, den du rechts an den `fahre <vorwärts> <solange>`-Baustein anbaust. Du kannst an den Eingang I1 einen Taster anschließen, und wenn du den gedrückt hälst, fährt mit diesem Befehl dein Roboter vorwärts. 
 
-![fahre vorwärts solange Eingang I1 ist an](/de/brickly/solange.png)
+![fahre vorwärts solange Eingang I1 ist an](solange.png)
 
 Statt *solange* kannst du auch *bis* auswählen. Damit kannst du einen Hinderniserkennungsroboter bauen, der solange vorwärts fährt, bis ein Hindernis den Taster an dem ausgewählten Eingang drückt.   
 
@@ -28,17 +28,17 @@ Statt *solange* kannst du auch *bis* auswählen. Damit kannst du einen Hindernis
 * `falls <> mache `: Nach *falls* kommt eine Bedingung, und in den Bauch des Bausteins nach *mache* kommt ein Befehl oder eine Befehlsblock. Dieser Befehl wird einmal ausgeführt, falls die Bedingung wahr ist.    
 Wenn du auf das Zahnrad links oben in diesem Baustein drückst, kannst du den Baustein noch erweitern. Es öffnet sich ein Kasten, der auf der linken Seite noch zwei Bausteine enthält. Wenn du einen der Bausteine an den 'falls'-Baustein auf der rechten Seite anbaust, erhälst du einen erweiterten 'falls'-Baustein. Wenn du mit dem Zusammenbau fertig bist, drückst du wieder auf das Zahnrad und der Kasten verschwindet. Nach *sonst falls* kannst du noch eine Bedingung und dann wieder einen Befehl einsetzen. Nach *sonst* kommt dann der Befehl, den der TXT ausführen soll, wenn alle anderen Bedingungen in diesem Baustein unwahr sind.     
 
-![wenn sonst falls](/de/brickly/sonstfalls.png)
+![wenn sonst falls](sonstfalls.png)
 
 * `<> <und> <>`: Hier kannst du zwei Bedingungs-Bausteine miteinander zu einer neuen Bedingung verknüpfen. Mit *und* müssen beide Bedingungen wahr sein, damit der Baustein den Wert *wahr* hat. 
 
-![und](/de/brickly/und.png)
+![und](und.png)
 
 Mit *oder* muss mindestens eine Bedingung wahr sein. Wenn beide Bedingungen unwahr sind, hat der Baustein auch den Wert *unwahr*. Diesen Baustein kannst du immer dort einsetzen, wo eine Bedingung gebraucht wird.  
 * `nicht`: diesen Baustein kannst du vor einen Bedingungs-Baustein einbauen, und er dreht diese Bedingung um: aus *wahr* wird *unwahr* und aus *unwahr* wird *wahr*.    
 
 ## Bausteine "Schleifen"    
-* `wiederhole`: s. [hier](/de/brickly/level-1.md#wiederhole)  
+* `wiederhole`: s. [hier](level-1.md#wiederhole)  
 * `wiederhole <10> mal: mache`: Hier gibst du die Anzahl der Wiederholungen an. Dein TXT führt dann die Befehle in dem Bauch des Bausteins 10 mal nacheinander aus. Du kannst auch eine andere Zahl eingeben.  
 * `wiederhole <solange>`: Hier gibst du eine Bedingung für die Wiederholung an. Wenn du *solange* auswählst, werden die Befehle nur dann ausgeführt, wie eine Bedingung wahr ist, dann aber immer wieder. Du kannst auch *bis* auswählen. Dann werden die Befehle so lange immer wieder ausgeführt, wie die angebene Bedingung wahr ist.    
 
@@ -49,16 +49,16 @@ Mit *oder* muss mindestens eine Bedingung wahr sein. Wenn beide Bedingungen unwa
 ## Bausteine "Text"     
 * `"< >"`: ein Textbaustein, den du über die Tastatur mit Text füllen kannst.   
 * `erstelle Text aus`: setzt zwei Texte zu einem Text zusammen.   
-* `gib aus "< >"`: wie [hier](/de/brickly/level-1.md#gibaus). Du kannst hier einen Text eingeben, oder einen Textbaustein oder einen Zahlenbaustein einbauen. Wenn du einen Bedingungsbaustein anbaust, wird "true" für *wahr* oder "false" für unwahr ausgegeben.     
+* `gib aus "< >"`: wie [hier](level-1.md#gibaus). Du kannst hier einen Text eingeben, oder einen Textbaustein oder einen Zahlenbaustein einbauen. Wenn du einen Bedingungsbaustein anbaust, wird "true" für *wahr* oder "false" für unwahr ausgegeben.     
 
 ## Neu im Kontextmenü
 * "Kommentar hinzufügen":  Hier kannst du einen Kommentar zu deinem Baustein oder dem Programm schreiben oder auch wieder löschen. Wenn du den Kommentar fertig geschrieben hast oder zum Lesen eines Kommentares, drückst du auf das kleine Fragezeichen.
 
-![Kommentar](/de/brickly/kommentar.png)
+![Kommentar](kommentar.png)
   
 * "Baustein zusammenfalten": Damit wird ein Baustein zusammengefaltet und platzsparender dargestellt. Du kannst ihn auch wieder entfalten.   
 
-![Zusammengefalteter Baustein](/de/brickly/gefaltet.png)
+![Zusammengefalteter Baustein](gefaltet.png)
 
 * "Baustein deaktivieren": deaktiviert den Baustein, so dass er nicht mehr im Programm verwendet wird. Aktivieren macht das wieder rückgängig.    
 

--- a/de/brickly/level-3.md
+++ b/de/brickly/level-3.md
@@ -4,13 +4,13 @@ Für die Fortgeschrittenen gibt es neue Bausteine für die Nutzung der Eingänge
 "Variablen sind Behälter im Speicher, die einen Namen haben und deren Inhalt sich während der Ausführung eines Programms ändern kann. Der Begriff der Variablen ist eines der wichtigsten Konzepte in Mathematik und Informatik. Mit der Verwendung von Variablen fängt das "wahre Programmieren" an." (Rüdeger Baumann)    
 Mit dieser Erklärung im Hinterkopf kannst du dir überlegen, wie du Variablen in deinem Programm nutzen kannst, z.B. um den Wert eines Eingangs abzuspeichern. Variablen sind auch nützlich, um an verschiedenen Stellen im Programm immer den gleichen Wert zu verwenden.  
 
-![Schematische Darstellung einer Variablen](/de/brickly/variable.png)  
+![Schematische Darstellung einer Variablen](variable.png)  
 
-Als erstes musst Du eine [Variable erstellen](/de/brickly/level-3.md#variableerstellen). Danach hast du Bausteine zur Verfügung, mit denen du die Variable nutzen kannst.    
+Als erstes musst Du eine [Variable erstellen](level-3.md#variableerstellen). Danach hast du Bausteine zur Verfügung, mit denen du die Variable nutzen kannst.    
 
 Außerdem kannst du jetzt verschiedene Programme mit unterschiedlichen Namen speichern. Dazu drückst du das Symbol mit den drei Strichen ganz rechts im Browser. Dann gibst du einen Namen für dein Programm ein, drückst auf "Neu" und schon hast du einen neuen Startbaustein mit einer leeren Arbeitsfläche zur Verfügung. Deine auf dem TXT gespeicherten Programme kannst du mit dem gleichen Symbol auswählen.  
 
-![Neues Programm anlegen](/de/brickly/speichern.png)
+![Neues Programm anlegen](speichern.png)
 
 ## Neue Bausteine bei "Eingänge"    
 * `<Spannung (mV)> an Eingang <E1>`: mit dem Eingangsbaustein kannst du einen der Eingänge an dem TXT abfragen. Was dir der Eingang liefert und welche physikalische Größe (*Spannung*, *Schalterzustand*, *Widerstand* oder *Distanz*) du auswählen musst, hängt von dem verwendeten Sensor ab. Du kannst den Eingangsbaustein als Zahlenbaustein verwenden. Bei den Widerständen musst du einen Moment warten, bis sie ihren endgültigen Wert erreicht haben.    
@@ -22,27 +22,27 @@ Außerdem kannst du jetzt verschiedene Programme mit unterschiedlichen Namen spe
   * Ultraschallsensor: misst die *Distanz*, also den Abstand zum nächsten Hindernis.  
   * Wärmesensor: liefert einen *Widerstand*, der mit steigender Temperatur sinkt.  
 
-![Eingang auslesen](/de/brickly/eingang.png)
+![Eingang auslesen](eingang.png)
   
 * `Temperatur <°C>`: diesen Baustein kannst Du verwenden, um aus dem Widerstandswert des Wärmesensor eine Temperatur zu berechnen. Dazu baust du ihn vor den Eingangsbaustein, bei dem du *Widerstand* auswählst. Du kannst die Einheit wählen: °C (Grad Celsius, die in Europa verwendete Einheit), °F (Fahrenheit, wird in den USA verwendet) und K (Kelvin, gibt die absolute Temperatur an).  
 
 ## Neue Bausteine bei "Ausgänge"    
 * `<100%> (ein)`: mit diesem Baustein kann man wählen, ob der Ausgang mit voller Stärke (100%) oder nur mit weniger Stärke betrieben werden soll. Damit kannst du einen Motor langsamer laufen lassen oder ein Lämpchen weniger hell leuchten lassen.  
-* `drehe <rechts> <90°>`<a name="drehegrad"></a>: wie [hier](/de/brickly/level-1.md#drehe). Jetzt kannst du aber den Winkel genau in Grad angeben. Damit du dir unter dem angegeben Winkel etwas vorstellen kannst, erscheint ein kleiner Kreis, auf dem du mit der Maus entlang fahren kannst, um den Winkel einzustellen.     
+* `drehe <rechts> <90°>`<a name="drehegrad"></a>: wie [hier](level-1.md#drehe). Jetzt kannst du aber den Winkel genau in Grad angeben. Damit du dir unter dem angegeben Winkel etwas vorstellen kannst, erscheint ein kleiner Kreis, auf dem du mit der Maus entlang fahren kannst, um den Winkel einzustellen.     
 
-![Drehwinkel einstellen](/de/brickly/winkel.png)
+![Drehwinkel einstellen](winkel.png)
 
 ## Neue Bausteine bei "Logik"     
 * `<> <=> <>`: Hier kannst du zwei Werte, z.B. zwei Zahlenbausteine miteinander vergleichen. An die erste Stelle baust du den einen Baustein, dann kannst du den Vergleich auswählen: *=* (gleich), *&ne;* (ungleich), *&lt;* (kleiner als), *&le;* (kleiner oder gleich), *&gt;* (größer als), *&ge;* (größer oder gleich). An die letzte Stelle kommt der zweite Wert. Du kannst Variablen, Text, Zahlen (z.B. von Eingängen) und Wahrheitswerte vergleichen.  
 
-![Vergleich](/de/brickly/vergleich.png)
+![Vergleich](vergleich.png)
 
 * `wahr`: ein Bedingungsbaustein, bei dem du *wahr* oder *unwahr* auswählen kannst. Damit kannst du z.B. einer Variablen einen Startwert geben.    
 
 ## Neuer Baustein bei "Schleifen"    
 * `zähle <i> von <1> bis <10> in Schritten von <1>: mache`: Das ist eine Zählschleife. Die Anzahl der Durchläufe, also wie oft die Befehle im Bauch des Bausteins ausgeführt werden, steht fest. Beim ersten Durchlauf ist der Zähler *i* 1, wird dann um 1 erhöht, usw. bis *i* 10 ist. Mit diesen Zahlen wird diese Schleife also 10 mal ausgeführt. Der Zähler (hier *i*) ist im Bauch des Bausteins bekannt. Du findest einen Zahlenbaustein dafür bei den Variablen. Damit kannst du z.B. zuerst nur 1 Sekunde warten, dann 2 usw..    
 
-![Zählschleife](/de/brickly/zaehlschleife.png)
+![Zählschleife](zaehlschleife.png)
 
 ## Neuer Baustein bei "Mathe"      
 * `ganzzahlige Zufallszahl zwischen <1> und <100>`: hier denkt sich der TXT eine ganze Zahl zwischen 1 und 100 aus. Wenn du als Grenzen 1 und 6 wählst, hast du eine Art Würfel.     
@@ -50,13 +50,13 @@ Außerdem kannst du jetzt verschiedene Programme mit unterschiedlichen Namen spe
 ## "Variablen"      
 * `Variable erstellen`<a name="variableerstellen"></a>: Wenn du auf diesen Baustein gedrückt hast, erscheint ein Fenster, in dem du den Namen deiner Variablen eingibst. Damit ist die Variable erstellt. Wähle einen möglichst aussagekräftigen Namen, unter dem sich auch ein anderer etwas vorstellen kann.  
 
-![Variable erstellen](/de/brickly/variableerstellen.png)
+![Variable erstellen](variableerstellen.png)
 
 * `setze <meineVariable> auf`: Hier kannst einen Eingangsbaustein oder einen Zahlenbaustein anbauen und damit einen Wert für deine Variable speichern.  
 * `erhöhe <meineVariable> um <1>`: mit diesem Baustein kannst du zu dem Wert deiner Variablen 1 oder eine andere Zahl dazuzählen. Das ist praktisch, wenn du Ereignisse zählen willst, z.B. wie oft dein Roboter gegen ein Hindernis gefahren ist.  
 * `<meineVariable>`: mit diesem Baustein kannst du deine Variable als Zahlenbaustein verwenden und in anderen Bausteine, z.B. in Textbausteine einbauen.    
 
-![Variablen-Gruppe](/de/brickly/gruppevariablen.png)
+![Variablen-Gruppe](gruppevariablen.png)
 
 
 ## Neu im Kontextmenü    

--- a/de/brickly/level-3.md
+++ b/de/brickly/level-3.md
@@ -1,4 +1,5 @@
 # Dritter Erfahrungsgrad "Fortgeschritten"    
+
 Für die Fortgeschrittenen gibt es neue Bausteine für die Nutzung der Eingänge, und du lernst Variablen kennen.   
 "Variablen sind Behälter im Speicher, die einen Namen haben und deren Inhalt sich während der Ausführung eines Programms ändern kann. Der Begriff der Variablen ist eines der wichtigsten Konzepte in Mathematik und Informatik. Mit der Verwendung von Variablen fängt das "wahre Programmieren" an." (Rüdeger Baumann)    
 Mit dieser Erklärung im Hinterkopf kannst du dir überlegen, wie du Variablen in deinem Programm nutzen kannst, z.B. um den Wert eines Eingangs abzuspeichern. Variablen sind auch nützlich, um an verschiedenen Stellen im Programm immer den gleichen Wert zu verwenden.  

--- a/de/brickly/level-4.md
+++ b/de/brickly/level-4.md
@@ -11,9 +11,9 @@ Außerdem kannst du jetzt eine Gruppe von Befehlen zu einer Funktion zusammenbau
 * `stoppe Motor <M1>`: stoppt den ausgewählten Motor.  
 * `Motor <M1> hat gestoppt`: dieser Bedingungsbaustein wird wahr, wenn der Motor angehalten hat, weil die angegebene Entfernung erreicht wurde.  
 * `kopple Motoren <M1> und <M2>`: zwei gekoppelte Motoren laufen gleichzeitig und mit gleicher Geschwindigkeit. Damit beide Motoren wirklich synchron laufen und auch zur gleichen Zeit ein Stopp-Signal geben, solltest Du bei beiden Motoren die gleiche Entfernung einstellen. Die Motoren können aber in unterschiedliche Richtung drehen: dann dreht sich der Fahrroboter.  
-* `fahre <vorwärts> <25> cm`: wie [hier](/de/brickly/level-1.md#fahre)  
-* `fahre <vorwärts> <solange>`: wie [hier](/de/brickly/level-2.md#fahresolange)  
-* `drehe <rechts> <90>`: wie [hier](/de/brickly/level-3.md#drehegrad)    
+* `fahre <vorwärts> <25> cm`: wie [hier](level-1.md#fahre)  
+* `fahre <vorwärts> <solange>`: wie [hier](level-2.md#fahresolange)  
+* `drehe <rechts> <90>`: wie [hier](level-3.md#drehegrad)    
 
 ## Neu in "Schleifen"       
 * `<die Schleife abbrechen>`: mit diesem Baustein kannst du den Durchlauf durch eine Schleife abbrechen. Das Programm springt dann sofort zu dem ersten Baustein nach der Schleife. Du kannst diesen Baustein nach einer Bedingung in einer Schleife einbauen, um z.B. in einer Zählschleife im Notfall abzubrechen. Du kannst auch auswählen *sofort mit dem nächsten Schleifendurchlauf fortfahren*, wenn in einer Schleife einige Befehle unter bestimmten Bedingungen nicht ausgeführt werden sollen. **Wichtig**: beide Bausteine funktionieren nicht bei der "Wiederhole"-Schleife (die ohne "solange", "bis" oder "10 mal"). Die ist eine Endlosschleife, die nur mit einem Drücken auf "Stopp" abgebrochen werden kann.    

--- a/de/brickly/level-4.md
+++ b/de/brickly/level-4.md
@@ -1,4 +1,5 @@
 # Vierter Erfahrungsgrad "Senior"    
+
 In diesem Erfahrungsgrad gibt es viele neue Bausteine für die Nutzung von Encoder-Motoren. Alle Motorbausteine findest du jetzt in einer eigenen Untergruppe "Motoren" unterhalb von "Ausgänge".    
 Außerdem kannst du jetzt eine Gruppe von Befehlen zu einer Funktion zusammenbauen. Damit wird ein langes Programm viel übersichtlicher.    
 

--- a/de/brickly/level-5.md
+++ b/de/brickly/level-5.md
@@ -1,7 +1,7 @@
 # Fünfter Erfahrungsgrad "Experte"    
 
 Dies ist der höchste Erfahrungsgrad für die Experten. Neu sind hier die Listen-Bausteine. Eine Liste ist eine durchnummerierte Reihe von Elementen. Über die Nummer kannst du auf jedes Element zugreifen. 
-![Liste](/de/brickly/list.png)  
+![Liste](list.png)  
 
 Die meisten Bausteine für Listen findest du in der neuen Gruppe "Listen", es gibt aber auch einen neuen Baustein unter "Schleifen" und einen bei "Mathe".      
 
@@ -12,9 +12,9 @@ Hier gibt es einige neue Bausteine für die Nutzung eines USB-Joysticks. Die Joy
 * `gleichzeitig`. Mit diesem Baustein kannst du Ausgänge gleichzeitig setzen, z.B. zwei Motoren gleichzeitig starten, ohne gekoppelte Encoder-Motoren zu verwenden. Der Baustein funktioniert nicht mit den Bausteinen aus der Untergruppe "Mobil" (da drehen zwei Motoren ohnehin gleichzeitig).     
 
 ## Neue Untergruppe in "Ausgänge": "Mobil"    
-* `fahre <vorwärts> <25> cm`: wie [hier](/de/brickly/level-1.md#fahre)  
-* `fahre <vorwärts> <solange>`: wie [hier](/de/brickly/level-2.md#fahresolange)  
-* `drehe <rechts> <90>`: wie [hier](/de/brickly/level-3.md#drehegrad)  
+* `fahre <vorwärts> <25> cm`: wie [hier](level-1.md#fahre)  
+* `fahre <vorwärts> <solange>`: wie [hier](level-2.md#fahresolange)  
+* `drehe <rechts> <90>`: wie [hier](level-3.md#drehegrad)  
 * `<90>°` und `<etwas> herum`: diese beiden Bausteine können an den `drehe`-Baustein angebaut werden, um den Drehwinkel einzustellen.    
 * `Mobilroboter-Konfiguration`: Wenn du einen anderen Fahrroboter als den aus dem TXT-Discovery-Set gebaut hast, kannst du mit diesem Baustein am Anfang deines Programms einstellen, an welchen Anschlüssen die Motoren angeschlossen sind, von welchem Typ sie sind, wie die Antriebsübersetzung (Motorachse zu Radachse) ist, wie groß der Raddurchmesser ist und wie der Abstand zwischen den Antriebsrädern ist. Mit der richtigen Konfiguration sollen die Befehle zum Fahren und Drehen auch für deinen selbstkonstruierten Fahrroboter funktionieren. Für das Discovery-Set wird dieser Baustein nicht benötigt.      
 
@@ -35,7 +35,7 @@ Hier gibt es einige neue Bausteine für die Nutzung eines USB-Joysticks. Die Joy
 * `Zufallszahl (0.0 - 1.0)`: liefert eine zufällige Gleitkommazahl zwischen 0.0 und 1.0.     
 
 ## Neu in "Text"    
-Hier findest du jetzt viele neue Bausteine, um Texte zu bearbeiten, Teile daraus zu finden usw.. Als "Experte" wirst du in dieser Gruppe finden, was du brauchst. Ein Baustein ist besonders nützlich: 
+Hier findest du jetzt viele neue Bausteine, um Texte zu bearbeiten, Teile daraus zu finden usw.. Als "Experte" wirst du in dieser Gruppe finden, was du brauchst. Ein Baustein ist besonders nützlich:
 * `gib aus in <> <"abc">`: gibt den angegebenen Text in der ausgewählten Farbe aus.    
 
 ## "Listen"    

--- a/de/brickly/level-5.md
+++ b/de/brickly/level-5.md
@@ -1,4 +1,5 @@
 # Fünfter Erfahrungsgrad "Experte"    
+
 Dies ist der höchste Erfahrungsgrad für die Experten. Neu sind hier die Listen-Bausteine. Eine Liste ist eine durchnummerierte Reihe von Elementen. Über die Nummer kannst du auf jedes Element zugreifen. 
 ![Liste](/de/brickly/list.png)  
 


### PR DESCRIPTION
The Jekyll setup used on http://cfw.ftcommunity.de/ needs some small, technical changes to the source code to display the pages properly.

* Without an empty line after the first heading, the `jekyll-titles-from-headings` module that is used on http://cfw.ftcommunity.de/ to automatically get the link text for the navigation menu does not pick up the heading.
* Relative links (and image sources) are needed because the Brickly user guide has a different URL path prefix on http://cfw.ftcommunity.de/ (`/de/programming/brickly/` instead of `/de/brickly/`) which breaks the absolute paths used originally.